### PR TITLE
Add agent liveliness and readiness probe to check the health of the agent using agent health check endpoint

### DIFF
--- a/incubator/gocd/README.md
+++ b/incubator/gocd/README.md
@@ -63,8 +63,8 @@ The following tables lists the configurable parameters of the GoCD chart and the
 | `server.service.nodeHttpsPort`             | GoCD server service node HTTPS port. **Note**: A random nodePort will get assigned if not specified           | `nil`               |  
 | `server.ingress.enabled`                   | Enable GoCD ingress.                                                                                          | `false`             |  
 | `server.ingress.hosts`                     | GoCD ingress hosts records.                                                                                   | `nil`               |
-| `server.livenessProbe.initialDelaySeconds` | GoCD server start up time.                                                                                    | `180`               |
-| `server.livenessProbe.periodSeconds`       | GoCD server heath check interval period.                                                                      | `5`                 |
+| `server.healthCheck.initialDelaySeconds`   | GoCD server start up time.                                                                                    | `180`               |
+| `server.healthCheck.periodSeconds`         | GoCD server heath check interval period.                                                                      | `5`                 |
 
 ### GoCD Agent
 
@@ -79,10 +79,10 @@ The following tables lists the configurable parameters of the GoCD chart and the
 | `agent.env.agentAutoRegisterResources`    | Comma separated list of GoCD Agent resources                                                        | `nil`                        |
 | `agent.env.agentAutoRegisterEnvironemnts` | Comma separated list of GoCD Agent environments                                                     | `nil`                        |
 | `agent.env.agentAutoRegisterHostname`     | GoCD Agent hostname                                                                                 | `nil`                        |
-| `agent.livenessProbe.enabled`             | Enable use of GoCD agent health checks.                                                             | `false`                      |
-| `agent.livenessProbe.initialDelaySeconds` | GoCD agent start up time.                                                                           | `180`                        |
-| `agent.livenessProbe.periodSeconds`       | GoCD agent heath check interval period.                                                             | `60`                         |
-| `agent.livenessProbe.failureThreshold`    | GoCD agent heath check failure threshold. After failure threshold timeout, agent will be restarted. | `60`                         |
+| `agent.healthCheck.enabled`               | Enable use of GoCD agent health checks.                                                             | `false`                      |
+| `agent.healthCheck.initialDelaySeconds`   | GoCD agent start up time.                                                                           | `180`                        |
+| `agent.healthCheck.periodSeconds`         | GoCD agent heath check interval period.                                                             | `60`                         |
+| `agent.healthCheck.failureThreshold`      | GoCD agent heath check failure threshold. After failure threshold timeout, agent will be restarted. | `60`                         |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 

--- a/incubator/gocd/README.md
+++ b/incubator/gocd/README.md
@@ -68,17 +68,21 @@ The following tables lists the configurable parameters of the GoCD chart and the
 
 ### GoCD Agent
 
-| Parameter                                 | Description                                     | Default                      |
-| ----------------------------------------- | ----------------------------------------------- | ---------------------------- |
-| `agent.replicaCount`                      | GoCD Agent replicas Count                       | `1`                          |
-| `agent.image.repository`                  | GoCD agent image                                | `gocd/gocd-agent-alpine-3.6` |
-| `agent.image.tag`                         | GoCD agent image tag                            | `.Chart.appVersion`          |
-| `agent.image.pullPolicy`                  | Image pull policy                               | `IfNotPresent`               |
-| `agent.env.goServerUrl`                   | GoCD Server Url                                 | `nil`                        |
-| `agent.env.agentAutoRegisterKey`          | GoCD Agent autoregister key                     | `nil`                        |
-| `agent.env.agentAutoRegisterResources`    | Comma separated list of GoCD Agent resources    | `nil`                        |
-| `agent.env.agentAutoRegisterEnvironemnts` | Comma separated list of GoCD Agent environments | `nil`                        |
-| `agent.env.agentAutoRegisterHostname`     | GoCD Agent hostname                             | `nil`                        |
+| Parameter                                 | Description                                                                                         | Default                      |
+| ----------------------------------------- | --------------------------------------------------------------------------------------------------- | ---------------------------- |
+| `agent.replicaCount`                      | GoCD Agent replicas Count                                                                           | `1`                          |
+| `agent.image.repository`                  | GoCD agent image                                                                                    | `gocd/gocd-agent-alpine-3.6` |
+| `agent.image.tag`                         | GoCD agent image tag                                                                                | `.Chart.appVersion`          |
+| `agent.image.pullPolicy`                  | Image pull policy                                                                                   | `IfNotPresent`               |
+| `agent.env.goServerUrl`                   | GoCD Server Url                                                                                     | `nil`                        |
+| `agent.env.agentAutoRegisterKey`          | GoCD Agent autoregister key                                                                         | `nil`                        |
+| `agent.env.agentAutoRegisterResources`    | Comma separated list of GoCD Agent resources                                                        | `nil`                        |
+| `agent.env.agentAutoRegisterEnvironemnts` | Comma separated list of GoCD Agent environments                                                     | `nil`                        |
+| `agent.env.agentAutoRegisterHostname`     | GoCD Agent hostname                                                                                 | `nil`                        |
+| `agent.livenessProbe.enabled`             | Enable use of GoCD agent health checks.                                                             | `false`                      |
+| `agent.livenessProbe.initialDelaySeconds` | GoCD agent start up time.                                                                           | `180`                        |
+| `agent.livenessProbe.periodSeconds`       | GoCD agent heath check interval period.                                                             | `60`                         |
+| `agent.livenessProbe.failureThreshold`    | GoCD agent heath check failure threshold. After failure threshold timeout, agent will be restarted. | `60`                         |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 

--- a/incubator/gocd/templates/gocd-agent-deployment.yaml
+++ b/incubator/gocd/templates/gocd-agent-deployment.yaml
@@ -57,6 +57,20 @@ spec:
           - name: GO_AGENT_SYSTEM_PROPERTIES
             value: {{ .Values.agent.env.goAgentSystemProperties }}
           {{- end }}
+          {{- if .Values.agent.livenessProbe.enabled }}
+          livenessProbe:
+            httpGet:
+              path: /health/v1/isConnectedToServer
+              port: 8152
+            initialDelaySeconds: {{ .Values.agent.livenessProbe.initialDelaySeconds }}
+            failureThreshold: {{ .Values.agent.livenessProbe.failureThreshold }}
+            periodSeconds: {{ .Values.agent.livenessProbe.periodSeconds }}
+          readinessProbe:
+            httpGet:
+              path: /health/v1/isConnectedToServer
+              port: 8152
+            initialDelaySeconds: {{ .Values.agent.livenessProbe.initialDelaySeconds }}
+          {{- end }}
           {{- if .Values.agent.persistence.enabled }}
           volumeMounts:
           - name: homego-vol

--- a/incubator/gocd/templates/gocd-agent-deployment.yaml
+++ b/incubator/gocd/templates/gocd-agent-deployment.yaml
@@ -57,19 +57,19 @@ spec:
           - name: GO_AGENT_SYSTEM_PROPERTIES
             value: {{ .Values.agent.env.goAgentSystemProperties }}
           {{- end }}
-          {{- if .Values.agent.livenessProbe.enabled }}
+          {{- if .Values.agent.healthCheck.enabled }}
           livenessProbe:
             httpGet:
               path: /health/v1/isConnectedToServer
               port: 8152
-            initialDelaySeconds: {{ .Values.agent.livenessProbe.initialDelaySeconds }}
-            failureThreshold: {{ .Values.agent.livenessProbe.failureThreshold }}
-            periodSeconds: {{ .Values.agent.livenessProbe.periodSeconds }}
+            initialDelaySeconds: {{ .Values.agent.healthCheck.initialDelaySeconds }}
+            failureThreshold: {{ .Values.agent.healthCheck.failureThreshold }}
+            periodSeconds: {{ .Values.agent.healthCheck.periodSeconds }}
           readinessProbe:
             httpGet:
               path: /health/v1/isConnectedToServer
               port: 8152
-            initialDelaySeconds: {{ .Values.agent.livenessProbe.initialDelaySeconds }}
+            initialDelaySeconds: {{ .Values.agent.healthCheck.initialDelaySeconds }}
           {{- end }}
           {{- if .Values.agent.persistence.enabled }}
           volumeMounts:

--- a/incubator/gocd/templates/gocd-server-deployment.yaml
+++ b/incubator/gocd/templates/gocd-server-deployment.yaml
@@ -44,13 +44,13 @@ spec:
             httpGet:
               path: /go/api/v1/health
               port: 8153
-            initialDelaySeconds: {{ .Values.server.livenessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.server.livenessProbe.periodSeconds }}
+            initialDelaySeconds: {{ .Values.server.healthCheck.initialDelaySeconds }}
+            periodSeconds: {{ .Values.server.healthCheck.periodSeconds }}
           readinessProbe:
             httpGet:
               path: /go/api/v1/health
               port: 8153
-            initialDelaySeconds: {{ .Values.server.livenessProbe.initialDelaySeconds }}
+            initialDelaySeconds: {{ .Values.server.healthCheck.initialDelaySeconds }}
           {{- if .Values.server.persistence.enabled }}
           volumeMounts:
           - name: godata-vol

--- a/incubator/gocd/values.yaml
+++ b/incubator/gocd/values.yaml
@@ -85,6 +85,13 @@ agent:
       size: 1Gi
       storageClass:
       ExistingClaim:
+
+  livenessProbe:
+    enabled: false
+    initialDelaySeconds: 180
+    periodSeconds: 60
+    failureThreshold: 60
+
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following

--- a/incubator/gocd/values.yaml
+++ b/incubator/gocd/values.yaml
@@ -25,7 +25,7 @@ server:
   # nodeSelector: {}
   # This is used to select which node to run the particular pod on. Remove the curly braces and adjust the node selector as necessary. This will select the node which matches the labels provided in the nodeSelector.
 
-  livenessProbe:
+  healthCheck:
     initialDelaySeconds: 180
     periodSeconds: 5
   env:
@@ -86,7 +86,7 @@ agent:
       storageClass:
       ExistingClaim:
 
-  livenessProbe:
+  healthCheck:
     enabled: false
     initialDelaySeconds: 180
     periodSeconds: 60


### PR DESCRIPTION
* By default, liveliness and readiness probes are disabled